### PR TITLE
Fix expense total translation key

### DIFF
--- a/frontend/src/components/ExpensesTable.tsx
+++ b/frontend/src/components/ExpensesTable.tsx
@@ -50,7 +50,7 @@ const ExpensesTable: React.FC = () => {
             <tr>
               <th className="p-3">{t('expenses.issuer')}</th>
               <th className="p-3">{t('expenses.date')}</th>
-              <th className="p-3 text-right">{t('expenses.total')}</th>
+              <th className="p-3 text-right">{t('expenses.totalAmount')}</th>
               <th className="p-3 text-right">{t('expenses.vat')}</th>
               <th className="p-3">{t('expenses.filename')}</th>
               <th className="p-3 text-center">{t('expenses.actions')}</th>
@@ -66,7 +66,7 @@ const ExpensesTable: React.FC = () => {
                 <tr key={expense.id} className="border-b border-border md:border-b-0">
                   <td data-label={t('expenses.issuer')} className="md:p-3 font-medium md:font-normal">{expense.issuerName}</td>
                   <td data-label={t('expenses.date')} className="md:p-3">{new Date(expense.date).toLocaleDateString()}</td>
-                  <td data-label={t('expenses.total')} className="md:p-3 md:text-right">{expense.totalAmount.toFixed(2)}</td>
+                  <td data-label={t('expenses.totalAmount')} className="md:p-3 md:text-right">{expense.totalAmount.toFixed(2)}</td>
                   <td data-label={t('expenses.vat')} className="md:p-3 md:text-right">{expense.vatAmount.toFixed(2)}</td>
                   <td data-label={t('expenses.filename')} className="md:p-3 truncate">{expense.fileName}</td>
                   <td className="md:p-3 md:text-center actions-cell">
@@ -88,7 +88,7 @@ const ExpensesTable: React.FC = () => {
         {expenses.length > 0 && (
           <div className="md:hidden mt-4 p-4 bg-secondary rounded-lg space-y-2 font-bold">
               <div className="flex justify-between">
-                  <span>{t('expenses.total')} ({t('expenses.total')})</span>
+                  <span>{t('expenses.total')} ({t('expenses.totalAmount')})</span>
                   <span>{totalExpenses.toFixed(2)}</span>
               </div>
               <div className="flex justify-between">

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -36,7 +36,7 @@
   "expenses.upload": "Upload Invoices (XML)",
   "expenses.issuer": "Issuer",
   "expenses.date": "Date",
-  "expenses.total": "Total Amount",
+  "expenses.totalAmount": "Total Amount",
   "expenses.vat": "VAT Credit",
   "expenses.filename": "Filename",
   "expenses.actions": "Actions",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -36,7 +36,7 @@
   "expenses.upload": "Subir Facturas (XML)",
   "expenses.issuer": "Emisor",
   "expenses.date": "Fecha",
-  "expenses.total": "Monto Total",
+  "expenses.totalAmount": "Monto Total",
   "expenses.vat": "Crédito IVA",
   "expenses.filename": "Archivo",
   "expenses.actions": "Acciones",

--- a/frontend/src/services/pdfGenerator.ts
+++ b/frontend/src/services/pdfGenerator.ts
@@ -71,7 +71,7 @@ export const generatePdf = (
   doc.text(t('expenses.title'), 14, lastY + 15);
   autoTable(doc, {
     startY: lastY + 20,
-    head: [[t('expenses.issuer'), t('expenses.date'), t('expenses.total'), t('expenses.vat')]],
+    head: [[t('expenses.issuer'), t('expenses.date'), t('expenses.totalAmount'), t('expenses.vat')]],
     body: expenses.map(exp => [
       exp.issuerName,
       new Date(exp.date).toLocaleDateString(),


### PR DESCRIPTION
## Summary
- rename the first `expenses.total` key to `expenses.totalAmount` in English and Spanish
- update references in `ExpensesTable` and `pdfGenerator` to use the new key for per-entry totals

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68799a1e6eac832e8925a820f993c50c